### PR TITLE
Use env for resources

### DIFF
--- a/apps/shipping/lib/shipping/application.ex
+++ b/apps/shipping/lib/shipping/application.ex
@@ -20,4 +20,41 @@ defmodule Shipping.Application do
       supervisor(Shipping.CargoAgent, []),
     ], strategy: :one_for_one, name: Shipping.Supervisor)
   end
+
+  @doc """
+  Set up a resource cache and return the path to that resource file.
+  Depending on the running environment (Mix.env) copy (or not) the files
+  from the resources directory into appropriate enviornment directory
+  """
+  def prepare_cache(resource_file_name) do
+    resource_dir = Application.get_env(:shipping, :resources_cache)
+    resource_file_path = Path.join(resource_dir, resource_file_name)
+    case Mix.env do
+      # In the development environment, only copy this file if it doesn't
+      # exist. This way, any activity is preserved between running of the app.
+      :dev ->
+        dev_dir = Application.get_env(:shipping, :dev_resources_cache)
+        # Create the directory if not there
+        if not File.exists?(dev_dir) do
+          File.mkdir!(dev_dir)
+        end
+        dev_file_path = Path.join(dev_dir, resource_file_name)
+        if not File.exists?(dev_file_path) do
+          File.copy!(resource_file_path, dev_file_path)
+        end
+        dev_file_path
+      # In the testing environment, always copy this file to its testing
+      # directory so that tests can run correctly.
+      :test ->
+        test_dir = Application.get_env(:shipping, :test_resources_cache)
+        # Create the directory if not there
+        if not File.exists?(test_dir) do
+          File.mkdir!(test_dir)
+        end
+        test_file_path = Path.join(test_dir, resource_file_name)
+        File.copy!(resource_file_path, test_file_path)
+        test_file_path
+    end
+  end
+
 end

--- a/apps/shipping/lib/shipping/application.ex
+++ b/apps/shipping/lib/shipping/application.ex
@@ -13,7 +13,9 @@ defmodule Shipping.Application do
     import Supervisor.Spec, warn: false
 
     Supervisor.start_link([
-      # Start up a supervised HandlingEventAgent instead of a Repo
+      # Start up a supervised HandlingEventAgent and a CargoAgent to be used
+      # in place of a database. Note that Repo is implemented in terms of calls
+      # to these agents.
       supervisor(Shipping.HandlingEventAgent, []),
       supervisor(Shipping.CargoAgent, []),
     ], strategy: :one_for_one, name: Shipping.Supervisor)

--- a/apps/shipping/lib/shipping/cargo_agent.ex
+++ b/apps/shipping/lib/shipping/cargo_agent.ex
@@ -9,9 +9,11 @@ defmodule Shipping.CargoAgent do
   when this Agent is started (start_link()). The backing store data is stored in
   JSON format.
   """
-  defp cache_file_path, do: Application.get_env(:shipping, :cargoes_cache)
+  @cargo_file "cargoes.json"
 
-  defstruct [cargoes: [], last_cargo_id: 0, cache: nil]
+  defstruct [cargoes: [], last_cargo_id: 0, cache: nil, cache_path: ""]
+
+  alias Shipping.Application
 
   # The Aggregate is Cargoes
   alias Shipping.Cargoes.Cargo
@@ -22,9 +24,16 @@ defmodule Shipping.CargoAgent do
   become part of the Agent's state.
   """
   def start_link do
-    {:ok, cache} = File.open(cache_file_path(), [:append, :read])
+    cache_path = Application.prepare_cache(@cargo_file)
+    {:ok, cache} = File.open(cache_path, [:append, :read])
     {cargoes, last_cargo_id} = load_from_cache(cache, {[], 0})
-    Agent.start_link(fn -> %__MODULE__{cache: cache, cargoes: cargoes, last_cargo_id: last_cargo_id} end, name: __MODULE__)
+    Agent.start_link(fn ->
+      %__MODULE__{cache: cache,
+                  cargoes: cargoes,
+                  last_cargo_id: last_cargo_id,
+                  cache_path: cache_path}
+      end,
+      name: __MODULE__)
   end
 
   # Reset the cargo status to "BOOKING"
@@ -42,10 +51,11 @@ defmodule Shipping.CargoAgent do
   end
 
   defp dump_to_cache() do
-    cache = Agent.get(__MODULE__, fn(struct) -> struct.cache end)
+    {cache, cache_path} = Agent.get(__MODULE__,
+                                    fn(struct) -> {struct.cache, struct.cache_path} end)
     File.close(cache)
-    File.rm(cache_file_path())
-    {:ok, new_cache} = File.open(cache_file_path(), [:append, :read])
+    File.rm(cache_path)
+    {:ok, new_cache} = File.open(cache_path, [:append, :read])
     all()
       |> Enum.map(
           fn(cargo) -> IO.write(new_cache, to_json(cargo) <> "\n")

--- a/apps/shipping/lib/shipping/cargoes/cargoes.ex
+++ b/apps/shipping/lib/shipping/cargoes/cargoes.ex
@@ -10,35 +10,6 @@ defmodule Shipping.Cargoes do
   alias Shipping.HandlingEvents.HandlingEvent
 
   @doc """
-  Returns the list of cargoes.
-
-  ## Examples
-
-      iex> list_cargoes()
-      [%Cargo{}, ...]
-
-  """
-  def list_cargoes do
-    Repo.all(Cargo)
-  end
-
-  @doc """
-  Gets a single cargo.
-
-  Raises `Ecto.NoResultsError` if the Cargo does not exist.
-
-  ## Examples
-
-      iex> get_cargo!(123)
-      %Cargo{}
-
-      iex> get_cargo!(456)
-      ** (Ecto.NoResultsError)
-
-  """
-  def get_cargo!(id), do: Repo.get!(Cargo, id)
-
-  @doc """
   Gets a cargo by its tracking id.
 
   Raises `Ecto.NoResultsError` if the Cargo does not exist.
@@ -53,24 +24,6 @@ defmodule Shipping.Cargoes do
 
   """
   def get_cargo_by_tracking_id!(tracking_id), do: Repo.get_by_tracking_id!(Cargo, tracking_id)
-
-  @doc """
-  Creates a cargo.
-
-  ## Examples
-
-      iex> create_cargo(%{field: value})
-      {:ok, %Cargo{}}
-
-      iex> create_cargo(%{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def create_cargo(attrs \\ %{}) do
-    %Cargo{}
-    |> Cargo.changeset(attrs)
-    |> Repo.insert()
-  end
 
   @doc """
   Updates a cargo.
@@ -88,22 +41,6 @@ defmodule Shipping.Cargoes do
     cargo
     |> Cargo.changeset(attrs)
     |> Repo.update()
-  end
-
-  @doc """
-  Deletes a Cargo.
-
-  ## Examples
-
-      iex> delete_cargo(cargo)
-      {:ok, %Cargo{}}
-
-      iex> delete_cargo(cargo)
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def delete_cargo(%Cargo{} = cargo) do
-    Repo.delete(cargo)
   end
 
   @doc """
@@ -147,6 +84,7 @@ defmodule Shipping.Cargoes do
     cargo = get_cargo_by_tracking_id!(handling_event.tracking_id)
     do_update_cargo_status([handling_event], :on_track, cargo)
   end
+
   defp do_update_cargo_status([%HandlingEvent{type: type} | handling_events],
                           _tracking_status,
                           %Cargo{status: status} = cargo) do
@@ -176,29 +114,6 @@ defmodule Shipping.Cargoes do
   defp next_status("UNLOAD", "ON CARRIER"), do: {:on_track, "IN PORT"}
   defp next_status("UNLOAD", "IN PORT"), do: {:off_track, "IN PORT"}
   defp next_status(_, status), do: {:off_track, status}
-
-  #############################################################################
-  # Support for Locations
-  #############################################################################
-  @location_map  %{
-    "Hongkong": "CHHKG",
-    "Melbourne": "AUMEL",
-    "Stockholm": "SESTO",
-    "Helsinki": "FIHEL",
-    "Chicago": "USCHI",
-    "Tokyo": "JPTKO",
-    "Hamburg": "DEHAM",
-    "Shanghai": "CNSHA",
-    "Rotterdam": "NLRTM",
-    "Goteborg": "SEGOT",
-    "Hangzhou": "CHHGH",
-    "New York": "USNYC",
-    "Dallas": "USDAL"
-  }
-
-  def location_map do
-    @location_map
-  end
 
   #############################################################################
   # Support for HandlingEvent types

--- a/apps/shipping/lib/shipping/handling_events/handling_events.ex
+++ b/apps/shipping/lib/shipping/handling_events/handling_events.ex
@@ -92,22 +92,6 @@ defmodule Shipping.HandlingEvents do
   end
 
   @doc """
-  Deletes a HandlingEvent.
-
-  ## Examples
-
-      iex> delete_handling_event(handling_event)
-      {:ok, %HandlingEvent{}}
-
-      iex> delete_handling_event(handling_event)
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def delete_handling_event(%HandlingEvent{} = handling_event) do
-    Repo.delete(handling_event)
-  end
-
-  @doc """
   Returns an `%Ecto.Changeset{}` for tracking handling_event changes.
 
   ## Examples

--- a/apps/shipping/lib/shipping/locations/locations.ex
+++ b/apps/shipping/lib/shipping/locations/locations.ex
@@ -1,0 +1,29 @@
+defmodule Shipping.Locations do
+  @moduledoc """
+  A place to hold the names of Locations
+  """
+
+  #############################################################################
+  # Support for Locations
+  #############################################################################
+  @location_map  %{
+    "Hongkong": "CHHKG",
+    "Melbourne": "AUMEL",
+    "Stockholm": "SESTO",
+    "Helsinki": "FIHEL",
+    "Chicago": "USCHI",
+    "Tokyo": "JPTKO",
+    "Hamburg": "DEHAM",
+    "Shanghai": "CNSHA",
+    "Rotterdam": "NLRTM",
+    "Goteborg": "SEGOT",
+    "Hangzhou": "CHHGH",
+    "New York": "USNYC",
+    "Dallas": "USDAL"
+  }
+
+  def location_map do
+    @location_map
+  end
+
+end

--- a/apps/shipping_web/lib/shipping_web/controllers/handling_event_controller.ex
+++ b/apps/shipping_web/lib/shipping_web/controllers/handling_event_controller.ex
@@ -2,7 +2,7 @@ defmodule ShippingWeb.HandlingEventController do
   use ShippingWeb,  :controller
 
   # The Aggregates
-  alias Shipping.{Cargoes, HandlingEvents}
+  alias Shipping.{Cargoes, HandlingEvents, Locations}
   # The broadcasting channel
   alias ShippingWeb.HandlingEventChannel
 
@@ -13,7 +13,7 @@ defmodule ShippingWeb.HandlingEventController do
   def new(conn, _params) do
     changeset = HandlingEvents.change_handling_event(%HandlingEvents.HandlingEvent{})
     render(conn, "new.html", changeset: changeset,
-                          location_map: Cargoes.location_map(),
+                          location_map: Locations.location_map(),
                           handling_event_type_map: Cargoes.handling_event_type_map())
   end
 
@@ -34,7 +34,7 @@ defmodule ShippingWeb.HandlingEventController do
           |> redirect(to: handling_event_path(conn, :index))
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset,
-                                location_map: Cargoes.location_map(),
+                                location_map: Locations.location_map(),
                                 handling_event_type_map: Cargoes.handling_event_type_map())
     end
   end

--- a/apps/shipping_web/lib/shipping_web/templates/cargo/show.html.eex
+++ b/apps/shipping_web/lib/shipping_web/templates/cargo/show.html.eex
@@ -52,7 +52,7 @@
             <td><%= DateTime.to_time(handling_event.completion_time) %></td>
             <td><%= handling_event.type %></td>
           </tr>
-          <%= end %>
+          <% end %>
         </tbody>
       </table>
     <% else %>

--- a/config/config.exs
+++ b/config/config.exs
@@ -14,12 +14,15 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
-# Configure for Shipping's location of the Cargo and Handling
-# Event agents resource files
+# Shipping's location of the Cargo and Handling
+# Event Agents resource files.
+# If Mix.env == :dev then copy these files to the resources/dev directory if
+# there are no files there
+# If Mix.env == :test then copy these files to the resources/test directory,
+# overwriting any existing files.
 app_dir = File.cwd!()
 config :shipping,
-  cargoes_cache: Path.join([app_dir, "resources", "cargoes.json"]),
-  handling_events_cache: Path.join([app_dir, "resources", "handling_events.json"])
+  resources_cache: Path.join([app_dir, "resources"])
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -14,6 +14,13 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+# Configure for Shipping's location of the Cargo and Handling
+# Event agents resource files
+app_dir = File.cwd!()
+config :shipping,
+  cargoes_cache: Path.join([app_dir, "resources", "cargoes.json"]),
+  handling_events_cache: Path.join([app_dir, "resources", "handling_events.json"])
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,3 +6,9 @@ config :logger, :console, format: "[$level] $message\n"
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.
 config :phoenix, :stacktrace_depth, 20
+
+# Where to find the resource files used during development. The files are
+# copied here *only* if the directory is empty.
+app_dir = File.cwd!()
+config :shipping,
+  dev_resources_cache: Path.join([app_dir, "resources", "dev"])

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,3 +2,9 @@ use Mix.Config
 
 # Print only warnings and errors during test
 config :logger, level: :warn
+
+# Where to find the resource files used during testing. The files are
+# copied here during test set up and overwrite any that are present.
+app_dir = File.cwd!()
+config :shipping,
+  test_resources_cache: Path.join([app_dir, "resources", "test"])


### PR DESCRIPTION
New environment variables determine how the resource files (cargoes.json and handling_events.json) are used depending on the  Mix environment: either :dev or :test. 

If :dev then copy the files to a dev directory (creating the directory if necessary) if there are none in this directory.

If :test then always copy the files to a test directory (creating the directory if necessary). This action ensures that tests based on the contents of these resources are reproducible.  