### PR TITLE
Display handling events in correct order

### DIFF
--- a/apps/shipping/lib/shipping/cargoes/cargoes.ex
+++ b/apps/shipping/lib/shipping/cargoes/cargoes.ex
@@ -57,7 +57,8 @@ defmodule Shipping.Cargoes do
   end
 
   @doc """
-  Gets the delivery history (all handling events to date) for a tracking id.
+  Gets the delivery history (all handling events to date) for a tracking id. And
+  then sorts it in descending order based on the completion date/time.
 
   Raises `Ecto.NoResultsError` if the Handling event does not exist.
 
@@ -66,6 +67,7 @@ defmodule Shipping.Cargoes do
   """
   def get_delivery_history_for_tracking_id(tracking_id) do
     DeliveryHistory.for_tracking_id(tracking_id)
+    |> Enum.sort(&(&1.completion_time >= &2.completion_time))
   end
 
   @doc """

--- a/apps/shipping/lib/shipping/handling_events/handling_event.ex
+++ b/apps/shipping/lib/shipping/handling_events/handling_event.ex
@@ -6,6 +6,10 @@ defmodule Shipping.HandlingEvents.HandlingEvent do
   # Cargoes Aggregates
   alias Shipping.Cargoes
 
+  # Note that handling events are stored in the order that they are received
+  # - the registration_time - so that they can be "replayed". They are usually
+  # displayed in the order that they happened - the completion_time - with the
+  # newest first.
 
   schema "handling_events" do
     field :completion_time, :utc_datetime
@@ -40,7 +44,7 @@ defmodule Shipping.HandlingEvents.HandlingEvent do
   defp validate_tracking_id(handling_event) do
     case Cargoes.get_cargo_by_tracking_id!(get_field(handling_event, :tracking_id)) do
       nil -> add_error(handling_event, :tracking_id, "Cannot find tracking number.")
-      cargo -> handling_event          
+      cargo -> handling_event
     end
   end
 

--- a/apps/shipping/lib/shipping/handling_events/handling_events.ex
+++ b/apps/shipping/lib/shipping/handling_events/handling_events.ex
@@ -22,7 +22,8 @@ defmodule Shipping.HandlingEvents do
   end
 
   @doc """
-  Gets all handling events for a tracking id.
+  Gets all handling events for a tracking id and returns them in
+  completion_time order with the newest first.
 
   Raises `Ecto.NoResultsError` if the Handling event does not exist.
 
@@ -37,6 +38,7 @@ defmodule Shipping.HandlingEvents do
   """
   def get_handling_events_by_tracking_id!(tracking_id) do
     Repo.get_by_tracking_id!(HandlingEvent, tracking_id)
+    |> Enum.sort(&(&1.completion_time >= &2.completion_time))
   end
 
   @doc """

--- a/apps/shipping_web/assets/js/handling_event.js
+++ b/apps/shipping_web/assets/js/handling_event.js
@@ -25,16 +25,39 @@ class HandlingEvent {
       channel.on("new_handling_event", handling_event => {
         let eventContainer = document.getElementById("handling-events")
         let template = document.createElement("tr")
+        let no_of_events = eventContainer.rows.length
 
+        // Note that the new id values for the date and time are constructed
+        // to not be the same as any other element.
+        // These ids do *NOT* indicate any kind of ordering of the events.
         template.innerHTML = `
           <td>${handling_event.voyage}</td>
           <td>${handling_event.location}</td>
-          <td>${handling_event.date}</td>
-          <td>${handling_event.time}</td>
+          <td id="completion-date-${no_of_events}">${handling_event.date}</td>
+          <td id="completion-time-${no_of_events}">${handling_event.time}</td>
           <td>${handling_event.type}</td>
         `
-        // Prepend the new handling event to the existing list
-        eventContainer.insertBefore(template, eventContainer.firstChild)
+        // Find a place for the new event in the displayed events table
+        // The following code assumes that the events table is sorted in
+        // descending order by completion date and time, i.e., the newest
+        // event appears as the top row of table.
+        let new_datetime = handling_event.date + handling_event.time
+        for (var i = 0; i < no_of_events; i++) {
+          var row = eventContainer.rows[i]
+          var row_date = row.querySelector("td[id*=completion-date]").innerHTML
+          var row_time = row.querySelector("td[id*=completion-time]").innerHTML
+          var row_datetime = row_date + row_time
+          if (new_datetime >= row_datetime) {
+            eventContainer.insertBefore(template, row)
+            break
+          }
+        }
+        // If the new event was not inserted then we append it to the table -
+        // make it the last row.
+        if (no_of_events == eventContainer.rows.length) {
+          eventContainer.insertBefore(template,
+                          eventContainer.lastChild.nextSibling)
+        }
         HandlingEvent.highlight_and_fade(template);
       });
       // Listen for a new_cargo_status message. The payload contains the new

--- a/apps/shipping_web/lib/shipping_web/templates/cargo/show.html.eex
+++ b/apps/shipping_web/lib/shipping_web/templates/cargo/show.html.eex
@@ -44,15 +44,15 @@
           </tr>
         </thead>
         <tbody id="handling-events">
-          <%= for handling_event <- @handling_events do %>
+          <%= Enum.with_index(@handling_events) |> Enum.map(fn({handling_event, index}) -> %>
           <tr>
             <td><%= handling_event.voyage %></td>
             <td><%= handling_event.location %></td>
-            <td><%= DateTime.to_date(handling_event.completion_time) %></td>
-            <td><%= DateTime.to_time(handling_event.completion_time) %></td>
+            <td id="completion-date-<%= index %>"><%= DateTime.to_date(handling_event.completion_time) %></td>
+            <td id="completion-time-<%= index %>"><%= DateTime.to_time(handling_event.completion_time) %></td>
             <td><%= handling_event.type %></td>
           </tr>
-          <% end %>
+          <% end ) %>
         </tbody>
       </table>
     <% else %>


### PR DESCRIPTION
Sort the handling events that are displayed in completion-time order.

Also, modify javascript to insert a new handling event received from the
web channel in the correct position in the displayed table.

Modify the show template so that it constructs unique ids for each date
and time element in a row in the table. While not strictly necessary,
this is considered good practice so that no element in a document has
the same id.